### PR TITLE
Fix cdn path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ publish: bin/porter$(FILE_EXT)
 	az storage blob upload -c porter -n atom.xml -f bin/atom.xml
 
 bin/porter$(FILE_EXT):
-	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/porter/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
+	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
 	chmod +x bin/porter$(FILE_EXT)
 
 install:


### PR DESCRIPTION
With the new CDN we don't use the extra porter path segment. I think it will fix `make publish` on master.

https://dev.azure.com/deislabs/porter/_build/results?buildId=4530&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=b24cf96b-e476-5cd6-97ae-776d6935d22f

```
curl -fsSLo bin/porter https://cdn.porter.sh/porter/canary/porter-linux-amd64
curl: (22) The requested URL returned error: 404 The specified blob does not exist.
Makefile:104: recipe for target 'bin/porter' failed
```